### PR TITLE
adds support for interval jobs on darwin

### DIFF
--- a/service.go
+++ b/service.go
@@ -20,6 +20,9 @@ func NewService(name, displayName, description string) (Service, error) {
 type Config struct {
 	Name, DisplayName, Description string
 
+	DarwinIntervalJob bool // Job is an interval job in launchd
+	DarwinInterval    int  // Interval to use for interval job
+
 	UserName  string   // Run as username.
 	Arguments []string // Run with arguments.
 
@@ -88,6 +91,7 @@ type Service interface {
 	Installer
 	Controller
 	Runner
+	Parameters
 	Logger
 	String() string
 }
@@ -102,6 +106,15 @@ type Runner interface {
 	// an error from Run.
 	// Both callbacks should return quickly and not block.
 	Run(onStart, onStop func() error) error
+}
+
+// Functions that control the parameters applied to a service
+type Parameters interface {
+	// Mark as service as an interval type service rather than a
+	// persistently running service.
+	//
+	// XXX Only applicable for Darwin launchd services.
+	IntervalMode(int) error
 }
 
 // Simple install and remove commands.

--- a/service_linux.go
+++ b/service_linux.go
@@ -227,6 +227,10 @@ func (s *linuxService) Stop() error {
 	}
 }
 
+func (s *linuxService) IntervalMode(interval int) error {
+	return fmt.Errorf("interval mode service only supported on darwin")
+}
+
 func (s *linuxService) Error(format string, a ...interface{}) error {
 	return s.logger.Err(fmt.Sprintf(format, a...))
 }

--- a/service_windows.go
+++ b/service_windows.go
@@ -162,6 +162,10 @@ func (ws *windowsService) Stop() error {
 	return err
 }
 
+func (s *windowsService) IntervalMode(interval int) error {
+	return fmt.Errorf("interval mode service only supported on darwin")
+}
+
 func (ws *windowsService) Error(format string, a ...interface{}) error {
 	if ws.logger == nil {
 		return nil


### PR DESCRIPTION
Adds support for interval based jobs using launchd in addition to the regular persistent jobs. Primary purpose for this is so we can use the service library for all launchd configuration rather then having alternate methods for interval based launchd jobs in MIG.
