### PR TITLE
Fix: hack really. Hardcode service to start after network is up. This…

### DIFF
--- a/service_linux.go
+++ b/service_linux.go
@@ -370,6 +370,7 @@ exec {{.Path}}
 const systemdScript = `[Unit]
 Description={{.Description}}
 ConditionFileIsExecutable={{.Path}}
+After=network.target
 
 [Service]
 StartLimitInterval=5


### PR DESCRIPTION
… may not be required by all services, but it is by

the user of this library (mig-agent) and perhaps _most_ services regardless.
A better future fix would be to make such things configurable
